### PR TITLE
Fix a typo in function name to microbatch_ops

### DIFF
--- a/deltalake/bronze/play.py
+++ b/deltalake/bronze/play.py
@@ -15,7 +15,7 @@ class BronzeContext:
 
 class AutoLoad:
     @staticmethod
-    def micorbatch_ops(_mdf, _batch_id, ctx: BronzeContext):
+    def microbatch_ops(_mdf, _batch_id, ctx: BronzeContext):
         """ repartitioning should also happen in this function
         """
         (_mdf.write.format('delta')


### PR DESCRIPTION
Just a smol typo 