### PR TITLE
Fix typo in Autoload.WriteData method call

### DIFF
--- a/deltalake/bronze/play.py
+++ b/deltalake/bronze/play.py
@@ -50,7 +50,7 @@ class AutoLoad:
     def WriteData(source_stream, ctx: BronzeContext):
         _write = (source_stream.writeStream
                                .option('checkpointLocation', ctx.checkpoint)
-                               .foreachBatch(lambda mdf, batch_id: AutoLoad.micorbatch_ops(mdf, batch_id, ctx))
+                               .foreachBatch(lambda mdf, batch_id: AutoLoad.microbatch_ops(mdf, batch_id, ctx))
                 )
 
         _query = _write.trigger(once=True).start()


### PR DESCRIPTION
## Overview

`pytest` fails for Bronze due to a typo with one of the method calls.

This is a very small fix to remove the typo 🚀 

## Error

<img width="755" alt="image" src="https://github.com/crankswagon/pyspark-tdd-scaffold/assets/72781965/b930cf62-38af-42b4-94db-464f83b5ee29">

## Results

<img width="761" alt="image" src="https://github.com/crankswagon/pyspark-tdd-scaffold/assets/72781965/c0c5b9f9-ce1e-49b8-9abc-ed9487afec14">
